### PR TITLE
Remove xenial series from charm.

### DIFF
--- a/charm/metamorphosis/metadata.yaml
+++ b/charm/metamorphosis/metadata.yaml
@@ -8,7 +8,6 @@ tags:
 min-juju-version: "2.4.0"
 subordinate: false
 series: 
-  - xenial
   - bionic
 requires:
   kafka:


### PR DESCRIPTION
xenial could be supported, but we'll standardize on bionic unless there
is some reason to deploy onto xenial.