### PR TITLE
Timestamp field topic config.

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -231,6 +231,39 @@ func TestLogMessages(t *testing.T) {
 		},
 		message:     `}{`,
 		logContains: `failed to unmarshal a data point`,
+	}, {
+		about: "timestamp field missing",
+		config: exporter.TopicConfig{
+			Topic: "test-topic",
+			Fields: map[string]string{
+				"a": "number",
+			},
+			TimestampField: "ts",
+		},
+		message:     `{"a": 4}`,
+		logContains: `timestamp field "ts" not present or incorrectly formatted`,
+	}, {
+		about: "timestamp field invalid type",
+		config: exporter.TopicConfig{
+			Topic: "test-topic",
+			Fields: map[string]string{
+				"a": "number",
+			},
+			TimestampField: "ts",
+		},
+		message:     `{"a": 4, "ts": 5}`,
+		logContains: `timestamp field "ts" not present or incorrectly formatted`,
+	}, {
+		about: "timestamp not rfc3339",
+		config: exporter.TopicConfig{
+			Topic: "test-topic",
+			Fields: map[string]string{
+				"a": "number",
+			},
+			TimestampField: "ts",
+		},
+		message:     `{"a": 4, "ts": "a long long time ago"}`,
+		logContains: `failed to parse timestamp field value "a long long time ago"`,
 	}}
 	for i, test := range tests {
 		c.Logf("running test %d: %s", i, test.about)

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -138,6 +138,33 @@ func TestConsumer(t *testing.T) {
 			point := p[0]
 			c.Assert(point.String(), qt.Equals, fmt.Sprintf(`test-topic a=42,b="just a string" 1556668800000000000`))
 		},
+	}, {
+		about: "timestamp field",
+		config: exporter.TopicConfig{
+			Topic: "test-topic",
+			Fields: map[string]string{
+				"a": "number",
+				"b": "string",
+				"d": "number",
+			},
+			TimestampField:    "ts",
+			TimestampAccuracy: "d",
+		},
+		data: map[string]interface{}{
+			"a":  42,
+			"b":  "just a string",
+			"c":  5,
+			"ts": "2019-01-02T15:04:05Z",
+		},
+		timestamps: []time.Time{
+			time.Date(2019, 5, 1, 12, 3, 5, 7, time.UTC),
+		},
+		assertBatches: func(c *qt.C, points client.BatchPoints) {
+			p := points.Points()
+			c.Assert(p, qt.HasLen, 1)
+			point := p[0]
+			c.Assert(point.String(), qt.Equals, fmt.Sprintf(`test-topic a=42,b="just a string" 1546387200000000000`))
+		},
 	}}
 
 	for i, test := range tests {


### PR DESCRIPTION
The config field allows overriding the timestamp of the datapoint with the value (RFC3339) of a field.