### PR TITLE
Configurable measurement names.

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -42,13 +42,14 @@ transformed.
   `n` in `top-n`.
 */
 type TopicConfig struct {
-	Topic     string                 `yaml:"topic"`
-	Type      string                 `yaml:"type,omitempty"`
-	Tags      map[string]string      `yaml:"tags,omitempty"`
-	Fields    map[string]string      `yaml:"fields,omitempty"`
-	Constants map[string]interface{} `yaml:"constants,omitempty"`
-	KeyFormat string                 `yaml:"key-format,omitempty"`
-	Number    int                    `yaml:"number,omitempty"`
+	Topic       string                 `yaml:"topic"`
+	Measurement string                 `yaml:"measurement,omitempty"`
+	Type        string                 `yaml:"type,omitempty"`
+	Tags        map[string]string      `yaml:"tags,omitempty"`
+	Fields      map[string]string      `yaml:"fields,omitempty"`
+	Constants   map[string]interface{} `yaml:"constants,omitempty"`
+	KeyFormat   string                 `yaml:"key-format,omitempty"`
+	Number      int                    `yaml:"number,omitempty"`
 
 	/* TimestampAccuracy specifies the accuracy to which timestamps will
 	   be truncated before writing to influx.
@@ -106,6 +107,13 @@ func (c TopicConfig) Validate() error {
 		return fmt.Errorf("invalid timestamp accuracy value: %q, topic: %q", c.TimestampAccuracy, c.Topic)
 	}
 	return nil
+}
+
+func (c TopicConfig) measurementName() string {
+	if c.Measurement == "" {
+		return c.Topic
+	}
+	return c.Measurement
 }
 
 type Config struct {
@@ -305,7 +313,7 @@ func addPoint(pointsList *[]*client.Point, tc TopicConfig, extraTags map[string]
 	for key, value := range extraTags {
 		tags[key] = value
 	}
-	p, err := client.NewPoint(tc.Topic, tags, fields, ts)
+	p, err := client.NewPoint(tc.measurementName(), tags, fields, ts)
 	if err != nil {
 		log.Printf("failed to create a new data point: %v", err)
 		return

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -340,6 +340,27 @@ func TestConsumer(t *testing.T) {
 			point := p[0]
 			c.Assert(point.String(), qt.Equals, fmt.Sprintf(`test-topic a=42,b="just a string" 1546387200000000000`))
 		},
+	}, {
+		about: "measurement name",
+		config: exporter.TopicConfig{
+			Topic:       "test-topic",
+			Measurement: "something_completely_different",
+			Fields: map[string]string{
+				"a": "number",
+			},
+		},
+		data: map[string]interface{}{
+			"a": 42,
+		},
+		timestamps: []time.Time{
+			time.Date(2019, 5, 1, 12, 0, 0, 0, time.UTC),
+		},
+		assertBatches: func(c *qt.C, points client.BatchPoints) {
+			p := points.Points()
+			c.Assert(p, qt.HasLen, 1)
+			point := p[0]
+			c.Assert(point.String(), qt.Equals, fmt.Sprintf(`something_completely_different a=42 1556712000000000000`))
+		},
 	}}
 
 	for i, test := range tests {


### PR DESCRIPTION
This adds support for specifying the InfluxDB measurement name when
processing a given topic.